### PR TITLE
add nightly builds with GitHub Actions

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,44 @@
+name: dev-build
+run-name: Build plugin for development
+on: [push, workflow_dispatch]
+jobs:
+  build-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup latest Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+
+      - name: Setup latest PNPM
+        uses: pnpm/action-setup@v2
+        with:
+          version: latest
+
+      - name: Update decky-frontend-lib
+        run: pnpm update decky-frontend-lib --latest
+
+      - name: Build frontend from source
+        run: |
+          pnpm i
+          pnpm run build
+
+      - name: Download Decky Plugin CLI
+        run: |
+          mkdir $(pwd)/cli
+          curl -L -o $(pwd)/cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/latest/download/decky"
+          chmod +x $(pwd)/cli/decky
+
+      - name: Build plugin
+        run: |
+          $(pwd)/cli/decky plugin build $(pwd)
+          unzip out/${{ github.event.repository.name }}.zip -d out/${{ github.event.repository.name }}
+
+      - name: Upload plugin
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.repository.name }}
+          path: out/${{ github.event.repository.name }}/*


### PR DESCRIPTION
Uses GitHub Actions to build and upload nightly CheatDeck ZIP as artifact.

Example: https://github.com/eXhumer/CheatDeck/actions/runs/7620761825