### PR TITLE
docs: warn about sidecars with nested Proton launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,16 @@ The selected program starts alongside the primary program in the same Proton/Win
 
 > [!NOTE]
 > This assumes Steam's launch target is the Windows program that should share
-> the sidecar's Proton/Wine environment. Linux-native game managers and
-> launchers that start their own Proton/umu process (for example, a launcher
-> shortcut managed by another Decky plugin) can run the sidecar in Steam's
-> outer prefix while the game runs in an inner prefix. For those launchers,
-> leave Steam's **Force the use of a specific Steam Play compatibility tool**
-> disabled when the launcher provides its own Proton selection, unless the
-> launcher documents an explicit sidecar integration.
+> the sidecar's Proton/Wine environment. A Windows launcher started directly
+> under Proton can share that environment with the sidecar. A Linux-native
+> game manager or launcher that starts its own Proton/umu process (for example,
+> a launcher shortcut managed by another Decky plugin) may instead leave the
+> sidecar attached to Steam's outer process while the game runs in a separate
+> inner Proton environment. CheatDeck does not control that nested boundary,
+> so sidecar support is not guaranteed for these launchers. If the launcher
+> provides its own Proton selection, leave Steam's **Force the use of a
+> specific Steam Play compatibility tool** disabled unless the launcher
+> documents an explicit sidecar integration.
 
 ### Language
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ The *Normal* tab provides the primary Sidecar Program and Language controls.
 
 The selected program starts alongside the primary program in the same Proton/Wine environment and stops when the primary program exits.
 
+> [!NOTE]
+> This assumes Steam's launch target is the Windows program that should share
+> the sidecar's Proton/Wine environment. Linux-native game managers and
+> launchers that start their own Proton/umu process (for example, a launcher
+> shortcut managed by another Decky plugin) can run the sidecar in Steam's
+> outer prefix while the game runs in an inner prefix. For those launchers,
+> leave Steam's **Force the use of a specific Steam Play compatibility tool**
+> disabled when the launcher provides its own Proton selection, unless the
+> launcher documents an explicit sidecar integration.
+
 ### Language
 
 Some games use environment locale variables to choose their language or regional behavior. Enable **Language** and select a locale code to set both `LANG` and `HOST_LC_ALL`. Disable the option to restore the default environment.


### PR DESCRIPTION
## What changed

Added a troubleshooting note explaining that CheatDeck's same Proton/Wine environment guarantee assumes Steam's launch target is the Windows program itself. A Windows launcher started directly under Proton can share that environment, while a Linux-native game manager or launcher that starts its own Proton/UMU process may leave the sidecar attached to the outer process while the game runs in a separate inner environment.

The note says that nested-launcher sidecar support is not guaranteed and recommends leaving Steam Force Compatibility disabled when the launcher owns Proton selection, unless the launcher documents a dedicated integration. No sidecar behavior or parser semantics changed.

Commits: `7a8991a`, `3d3cf1c`  
Branch: `docs/unifideck-nested-proton-sidecars`  
Base: `main`

## Validation

- `npm test`: 75 tests passed;
- `npm run typecheck`: passed;
- `npm run build`: passed;
- repository lint reports 36 pre-existing formatting diagnostics in untouched files.
